### PR TITLE
Check whether loaded textures conform to the 'Power of Two' rule

### DIFF
--- a/source/RouteChecker/TextureManager.cs
+++ b/source/RouteChecker/TextureManager.cs
@@ -267,6 +267,19 @@ namespace OpenBve
 					Textures[i].Transparency = TextureTransparencyMode.None;
 				}
 				Textures[i].IsRGBA = Textures[i].Transparency != TextureTransparencyMode.None | LoadMode != TextureLoadMode.Normal;
+				//Check that our image is a valid power of two
+				int tw, th;
+				GetImageDimensions(FileName, out tw, out th);
+				int w = Interface.RoundToPowerOfTwo(tw);
+				int h = Interface.RoundToPowerOfTwo(th);
+				if (w != tw)
+				{
+					Interface.AddMessage(Interface.MessageType.Information, false, "The Texture: " + FileName + " has a width of " + tw + " . This is not a valid power of two.");
+				}
+				if (h != th)
+				{
+					Interface.AddMessage(Interface.MessageType.Information, false, "The Texture: " + FileName + " has a height of " + th + " . This is not a valid power of two.");
+				}
 				return i;
 			}
 		}


### PR DESCRIPTION
Adds an error message when a texture is loaded which does not conform to the 'Power of Two' rule. (e.g. _1px, 2px, 4px, 8px_ etc. etc.)

The error is only tagged with Information, as it's not really that important, & the main program will automatically resize to suit.

Other thoughts on (probably) useful stuff to be added WRT to texture loading:
* Check color depth of the image, and complain if it's not a minimum of 16-bit. (A major cause of transparency issues is that the color depths are interpreted differently in various places....)
* Check image format, and potentially complain if not PNG. (If we're doing this, do it properly, so that the optimum formats are used at all times)
* Check that the image is not a stupid size. (I'm aware of one 4000+ px snow texture in the NYCTA routes, which is completely excessive)